### PR TITLE
webpack dotenv instead of webpack DefinePlugin

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const webpack = require('webpack');
-
+const Dotenv = require('dotenv-webpack');
+var envfile = (process.env.NODE_ENV == 'development') ? 'example1.env' : 'example2.env'; // as in question be undefined, so  'example2.env' choosen
 module.exports = {
     externals: {
         stompjs: '@stomp/stompjs',
@@ -31,6 +32,7 @@ module.exports = {
         minimize: false
     },
     plugins: [
+        new Dotenv ({path: envfile, silent: false}),
         new webpack.DefinePlugin({
             ENVIRONMENT: JSON.stringify(process.env.NODE_ENV),
             ANOTHER_VARIABLE: JSON.stringify("another variable value"),


### PR DESCRIPTION
could use ```const Dotenv = require('dotenv-webpack');``` and ``` var envfile = (process.env.NODE_ENV == 'development') ? 'example1.env' : 'example2.env'; // as in question be undefined, so  'example2.env' choosen ``` for env vars logic